### PR TITLE
fix: upgrade js-yaml to patched version (GHSA-5p4m-2wfm-xmqj)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-desktop",
-  "version": "1.4.2",
+  "version": "1.4.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-desktop",
-      "version": "1.4.2",
+      "version": "1.4.17",
       "license": "MIT",
       "dependencies": {
         "electron-updater": "^6.8.9"
@@ -2337,9 +2337,20 @@
       }
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "claude-desktop",
   "version": "1.4.17",
-  "description": "Claude AI Native Desktop App für Linux",
+  "description": "Claude AI Native Desktop App f\u00fcr Linux",
   "main": "main.js",
   "license": "MIT",
   "homepage": "https://github.com/simonlinuxcraft/claude-ai-desktop-app",
@@ -39,7 +39,7 @@
       "icon": "icon.png",
       "category": "Development;Utility",
       "synopsis": "Claude AI Desktop Client",
-      "description": "Eine schnelle, native Desktop-App für Claude AI",
+      "description": "Eine schnelle, native Desktop-App f\u00fcr Claude AI",
       "maintainer": "Simon Gettkandt",
       "desktop": {
         "entry": {
@@ -103,5 +103,31 @@
   "devDependencies": {
     "electron": "^41.7.1",
     "electron-builder": "^26.15.2"
+  },
+  "overrides": {
+    "app-builder-lib": {
+      "js-yaml": "4.3.1"
+    },
+    "builder-util": {
+      "js-yaml": "4.3.1"
+    },
+    "dmg-builder": {
+      "js-yaml": "4.3.1"
+    },
+    "electron-builder": {
+      "js-yaml": "4.3.1"
+    },
+    "electron-builder-squirrel-windows": {
+      "js-yaml": "4.3.1"
+    },
+    "electron-publish": {
+      "js-yaml": "4.3.1"
+    },
+    "electron-updater": {
+      "js-yaml": "4.3.1"
+    },
+    "js-yaml": {
+      "js-yaml": "4.3.1"
+    }
   }
 }


### PR DESCRIPTION
## Summary
Upgrade js-yaml from 4.1.1 to 4.3.1, 3.15.1 to fix GHSA-5p4m-2wfm-xmqj.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | GHSA-5p4m-2wfm-xmqj |
| **Severity** | HIGH |
| **Scanner** | trivy |
| **Rule** | `GHSA-5p4m-2wfm-xmqj` |
| **File** | `package-lock.json` (dependency: `js-yaml`) |
| **Assessment** | Present in dependency tree, not confirmed reachable |

**Description**: JS-YAML: Quadratic CPU consumption in !!omap resolution (3.x and 4.x) — CVE-2026-59870 fix not backported

## Changes
- `package.json`
- `package-lock.json`

## Behavior Preservation
This change touches only dependency manifests (`package.json`, `package-lock.json`); no source file in the repository is modified.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*

<!-- orbis-meta: rule=GHSA-5p4m-2wfm-xmqj scanner=trivy vuln=GHSA-5p4m-2wfm-xmqj -->
